### PR TITLE
drop stream pipelining in favor of buffers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ const readFromInput = () => {
 $loadButton.addEventListener('click', async () => {
   $loadStatus.textContent = 'Started loading, please wait...';
   const stream = readFromInput();
-  parseStream(stream, storage, () => { $loadStatus.textContent = 'Done loading'; });
+  parseStream(stream, storage, (bytes) => { $loadStatus.textContent = `Done loading ${bytes} bytes.`; });
 });
 
 $stopButton.addEventListener('click', () => {
@@ -41,6 +41,6 @@ $runButton.addEventListener('click', async () => {
   $loadStatus.textContent = 'Started playback';
   abortAutoplay = new AbortController();
   const sequenceGen = createSequence(storage)(0)();
-  const result = await runSequence(abortAutoplay, sequenceGen, drawHandler);
+  await runSequence(abortAutoplay, sequenceGen, drawHandler);
   $loadStatus.textContent = 'Finished playback';
 });


### PR DESCRIPTION
Using stream pipelining and parsing was a fun experiment, but either they are too slow, or I messed up. In any case, stream handling is now dropped, and the file blob will be parsed using ArrayBuffers. This makes loading times neglegible (1-2 seconds including the gzip decompression). I will come back to file loading with streams once iterator-helpers are stage-3.