### PR TITLE
fix repeatedly pressing play button

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,8 @@ $stopButton.addEventListener('click', () => {
 });
 
 $runButton.addEventListener('click', async () => {
+  // abort existing sequence
+  abortAutoplay?.abort();
   $loadStatus.textContent = 'Started playback';
   abortAutoplay = new AbortController();
   const sequenceGen = createSequence(storage)(0)();


### PR DESCRIPTION
Repeatedly pressing the play button would just create another sequence without terminating an already running one, which lead to entertaining issues.
Now, pressing the play button will always cancel the current sequence and restart playback. In the future, there will be a 'pause' functionality.